### PR TITLE
Fixing typo characters

### DIFF
--- a/nerfstudio/utils/writer.py
+++ b/nerfstudio/utils/writer.py
@@ -389,7 +389,7 @@ class LocalWriter:
             if not self.has_printed and self.config.max_log_size:
                 CONSOLE.log(
                     f"Printing max of {self.config.max_log_size} lines. "
-                    "Set flag çççç[yellow]--logging.local-writer.max-log-size=0[/yellow] "
+                    "Set flag [yellow]--logging.local-writer.max-log-size=0[/yellow] "
                     "to disable line wrapping."
                 )
             latest_map, new_key = self._consolidate_events()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28953513/211330912-02cb17d0-096c-42dc-b3f1-5b32df2749cc.png)
There was a  typo that needed to be fixed. Check the image, please.