### PR TITLE
Add to readme a point about CLI parameter ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ For a full list of included models run `ns-train --help`. Please refer to the [d
 
 Each model contains many parameters that can be changed, too many to list here. Use the `--help` command to see the full list of configuration options.
 
-**Note, that order of parameters matters! You cannot set `--machine.num-gpus` after the `--data` parameter**
+**Note, that order of parameters matters! For example, you cannot set `--machine.num-gpus` after the `--data` parameter**
 
 ```bash
 ns-train neus-facto --help

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ For a full list of included models run `ns-train --help`. Please refer to the [d
 
 Each model contains many parameters that can be changed, too many to list here. Use the `--help` command to see the full list of configuration options.
 
+**Note, that order of parameters matters! You cannot set `--machine.num-gpus` after the `--data` parameter**
+
 ```bash
 ns-train neus-facto --help
 ```


### PR DESCRIPTION
I spent some time trying to understand why my custom parameters are not recognized, and then realized that order matters -> added that to readme.