### PR TITLE
Update sdfstudio_dataparser.py

### DIFF
--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -185,7 +185,7 @@ class SDFStudio(DataParser):
             indices = indices[:: self.config.skip_every_for_val_split]
         else:
             # if you use this option, training set should not contain any image in validation set
-            if self.config.train_val_no_split:
+            if self.config.train_val_no_overlap:
                 indices = [i for i in indices if i % self.config.skip_every_for_val_split != 0]
 
         image_filenames = []

--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -164,6 +164,8 @@ class SDFStudioDataParserConfig(DataParserConfig):
     the last element is the most similar to the first (ref)"""
     skip_every_for_val_split: int = 1
     """sub sampling validation images"""
+    train_val_no_overlap: bool = False
+    """remove selected / sampled validation images from training set"""
     auto_orient: bool = False
 
 
@@ -182,8 +184,9 @@ class SDFStudio(DataParser):
         if split != "train" and self.config.skip_every_for_val_split >= 1:
             indices = indices[:: self.config.skip_every_for_val_split]
         else:
-            # training set should not contain any image in validation set
-            indices = [i for i in indices if i % self.config.skip_every_for_val_split != 0]
+            # if you use this option, training set should not contain any image in validation set
+            if self.config.train_val_no_split:
+                indices = [i for i in indices if i % self.config.skip_every_for_val_split != 0]
 
         image_filenames = []
         depth_images = []

--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -181,6 +181,9 @@ class SDFStudio(DataParser):
         # subsample to avoid out-of-memory for validation set
         if split != "train" and self.config.skip_every_for_val_split >= 1:
             indices = indices[:: self.config.skip_every_for_val_split]
+        else:
+            # training set should not contain any image in validation set
+            indices = [i for i in indices if i % self.config.skip_every_for_val_split != 0]
 
         image_filenames = []
         depth_images = []


### PR DESCRIPTION
Explicitly split training set and validation set, when there is no split provided. The default validation split will be the indices that can be divided exactly by an integer, i.e. `self.config.skip_every_for_val_split`. 

Current implementation might cause confusion as validation set is contained by the training set.

Thanks for your wonderful project and your effort.