### PR TITLE
fix: target nerfacc version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "mediapy==1.1.0",
     "msgpack==1.0.4",
     "msgpack_numpy==0.4.8",
-    "nerfacc>=0.2.1",
+    "nerfacc==0.3.5",
     "open3d>=0.16.0",
     "opencv-python==4.6.0.66",
     "plotly==5.7.0",


### PR DESCRIPTION
The project default install the latest version of `nerfacc`, which cause the error:

```
ImportError: cannot import name 'OccupancyGrid' from 'nerfacc'
```

Fixed it by targeting the version `nerfacc==0.3.5` refer to https://github.com/nerfstudio-project/nerfstudio/blob/c256dc2bf95e2ef8d2dcc13403c551700e031df4/pyproject.toml#L33