### PR TITLE
A sanity check before training the model

### DIFF
--- a/nerfstudio/configs/base_config.py
+++ b/nerfstudio/configs/base_config.py
@@ -134,6 +134,8 @@ class LoggingConfig(PrintableConfig):
 class TrainerConfig(PrintableConfig):
     """Configuration for training regimen"""
 
+    sanity_check: bool = False
+    """Whether run sanity check before training start."""
     steps_per_save: int = 1000
     """Number of steps between saves."""
     steps_per_eval_batch: int = 500

--- a/nerfstudio/engine/trainer.py
+++ b/nerfstudio/engine/trainer.py
@@ -342,7 +342,7 @@ class Trainer:
             writer.put_dict(name="Eval Metrics Dict", scalar_dict=eval_metrics_dict, step=step)
 
         # one eval image
-        if step_check(step, self.config.trainer.steps_per_eval_image):
+        if step_check(step, self.config.trainer.steps_per_eval_image, run_at_zero=self.config.trainer.sanity_check):
             with TimeWriter(writer, EventName.TEST_RAYS_PER_SEC, write=False) as test_t:
                 metrics_dict, images_dict = self.pipeline.get_eval_image_metrics_and_images(step=step)
             writer.put_time(


### PR DESCRIPTION
It is advisable to verify the GPU memory requirements of both the training and evaluation stages before training a model. Users can make necessary adjustments to ensure the total GPU memory usage does not exceed the GPU memory limit. This little feature would prevent training from being aborted due to insufficient GPU memory.