### PR TITLE
Training with masked images

### DIFF
--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -15,6 +15,7 @@
 """Data parser for friends dataset"""
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Optional, Type
@@ -226,9 +227,11 @@ class SDFStudio(DataParser):
                 mask = np.array(Image.open(mask_filename), dtype=np.float32) / 255.0
                 if len(mask.shape) == 3:
                     mask = mask[..., 0]
+                if self.config.train_with_masked_imgs or self.config.sample_from_mask:
+                    masked_img_dir_path = self.config.data / self.config.masked_img_dir
+                    os.makedirs(str(masked_img_dir_path), exist_ok=True)
 
             if self.config.train_with_masked_imgs:
-                masked_img_dir_path = self.config.data / self.config.masked_img_dir
                 image_filename = create_masked_img(image_filename, mask_filename, masked_img_dir_path)
 
             if self.config.include_foreground_mask:
@@ -238,7 +241,7 @@ class SDFStudio(DataParser):
             if self.config.sample_from_mask:
                 # nerfstudio's pixel sampler requires single channel masks
                 mask_img = Image.fromarray((255.0 * mask).astype(np.uint8))
-                mask_filename = mask_filename.parent / self.config.masked_img_dir / mask_filename.name
+                mask_filename = masked_img_dir_path / mask_filename.name
                 mask_img.save(mask_filename)
                 mask_filenames.append(mask_filename)
 

--- a/nerfstudio/data/utils/data_utils.py
+++ b/nerfstudio/data/utils/data_utils.py
@@ -61,7 +61,6 @@ def create_masked_img(img_filepath: Path, mask_filepath: Path, output_dir: Path)
     """
     img = np.array(Image.open(img_filepath), dtype=np.float32)
     mask = np.array(Image.open(mask_filepath), dtype=np.float32) / 255.0
-    os.makedirs(str(output_dir), exist_ok=True)
     assert len(img.shape) == 3
     if img.shape[-1] == 4:
         img = img[:, :, :3]

--- a/nerfstudio/data/utils/data_utils.py
+++ b/nerfstudio/data/utils/data_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Utility functions to allow easy re-use of common operations across dataloaders"""
+import os
 from pathlib import Path
 from typing import List, Tuple, Union
 
@@ -51,3 +52,24 @@ def get_semantics_and_mask_tensors_from_path(
     semantics = torch.from_numpy(np.array(pil_image, dtype="int64"))[..., None]
     mask = torch.sum(semantics == mask_indices, dim=-1, keepdim=True) == 0
     return semantics, mask
+
+
+def create_masked_img(img_filepath: Path, mask_filepath: Path, output_dir: Path) -> Path:
+    """
+    Utility function to mask an image using provided mask and store it on disk.
+    Output_dir is absolute path where to store the masked image.
+    """
+    img = np.array(Image.open(img_filepath), dtype=np.float32)
+    mask = np.array(Image.open(mask_filepath), dtype=np.float32) / 255.0
+    os.makedirs(str(output_dir), exist_ok=True)
+    assert len(img.shape) == 3
+    if img.shape[-1] == 4:
+        img = img[:, :, :3]
+    if len(mask.shape) == 2:
+        mask = mask[..., np.newaxis]
+
+    masked_image = Image.fromarray((img * mask).astype(np.uint8))
+    masked_image_filename = output_dir / (img_filepath.stem + "_masked" + img_filepath.suffix)
+    masked_image.save(masked_image_filename)
+
+    return masked_image_filename


### PR DESCRIPTION
* This feature is currently implemented only for the ```sdfstudio_dataparser```
* Add option to create train images with masked out objects using foreground masks
```
ns-train neus-facto --pipeline.model.sdf-field.inside-outside False --vis viewer --experiment-name neus-facto-dtu65 sdfstudio-data --data data/sdfstudio-demo-data/dtu-scan65 --train_with_masked_imgs True 
```
Result:
<img src="https://github.com/autonomousvision/sdfstudio/assets/63703454/e1d2e05e-2ba9-488d-98d1-b81b973fe8d3" width=50% height=50%>

* Add option to sample pixels only from masked regions
```
ns-train neus-facto --pipeline.model.sdf-field.inside-outside False --vis viewer --experiment-name neus-facto-dtu65 sdfstudio-data --data data/sdfstudio-demo-data/dtu-scan65 --sample_from_mask True 
```
Result:
<img src="https://github.com/autonomousvision/sdfstudio/assets/63703454/5817223f-f1f9-47c6-a50b-87ce07811840" width=50% height=50%>

This feature is useful for 3D object reconstruction. Using masked train images, we get a clean mesh of an object without background (1st image). Alternatively, we can train with normal images and sample pixels only from masked regions, but it leads to a bit noisy reconstruction (2nd image). still dont know why is that, maybe @niujinshuchong can comment on this.

Related issues: https://github.com/autonomousvision/sdfstudio/issues/11, https://github.com/autonomousvision/sdfstudio/issues/68, https://github.com/autonomousvision/sdfstudio/issues/84