### PR TITLE
fix num_proposal_samples_per_ray type

### DIFF
--- a/docs/developer_guides/pipelines/models.md
+++ b/docs/developer_guides/pipelines/models.md
@@ -82,7 +82,7 @@ class NerfactoModelConfig(ModelConfig):
     """How far along the ray to stop sampling."""
     background_color: Literal["background", "last_sample"] = "last_sample"
     """Whether to randomize the background color."""
-    num_proposal_samples_per_ray: Tuple[int] = (64,)
+    num_proposal_samples_per_ray: Tuple[int, ...] = (64,)
     """Number of samples per ray for the proposal network."""
     num_nerf_samples_per_ray: int = 64
     """Number of samples per ray for the nerf network."""

--- a/nerfstudio/model_components/ray_samplers.py
+++ b/nerfstudio/model_components/ray_samplers.py
@@ -499,7 +499,7 @@ class ProposalNetworkSampler(Sampler):
 
     def __init__(
         self,
-        num_proposal_samples_per_ray: Tuple[int] = (64,),
+        num_proposal_samples_per_ray: Tuple[int, ...] = (64,),
         num_nerf_samples_per_ray: int = 32,
         num_proposal_network_iterations: int = 2,
         use_uniform_sampler: bool = False,

--- a/nerfstudio/models/bakedsdf.py
+++ b/nerfstudio/models/bakedsdf.py
@@ -44,7 +44,7 @@ class BakedSDFModelConfig(VolSDFModelConfig):
     """BakedSDF Model Config"""
 
     _target: Type = field(default_factory=lambda: BakedSDFFactoModel)
-    num_proposal_samples_per_ray: Tuple[int] = (256, 96)
+    num_proposal_samples_per_ray: Tuple[int, ...] = (256, 96)
     """Number of samples per ray for the proposal network."""
     num_neus_samples_per_ray: int = 48
     """Number of samples per ray for the nerf network."""

--- a/nerfstudio/models/nerfacto.py
+++ b/nerfstudio/models/nerfacto.py
@@ -76,7 +76,7 @@ class NerfactoModelConfig(ModelConfig):
     """Maximum resolution of the hashmap for the base mlp."""
     log2_hashmap_size: int = 19
     """Size of the hashmap for the base mlp"""
-    num_proposal_samples_per_ray: Tuple[int] = (256, 96)
+    num_proposal_samples_per_ray: Tuple[int, ...] = (256, 96)
     """Number of samples per ray for the proposal network."""
     num_nerf_samples_per_ray: int = 48
     """Number of samples per ray for the nerf network."""

--- a/nerfstudio/models/neus_facto.py
+++ b/nerfstudio/models/neus_facto.py
@@ -44,7 +44,7 @@ class NeuSFactoModelConfig(NeuSModelConfig):
     """UniSurf Model Config"""
 
     _target: Type = field(default_factory=lambda: NeuSFactoModel)
-    num_proposal_samples_per_ray: Tuple[int] = (256, 96)
+    num_proposal_samples_per_ray: Tuple[int, ...] = (256, 96)
     """Number of samples per ray for the proposal network."""
     num_neus_samples_per_ray: int = 48
     """Number of samples per ray for the nerf network."""


### PR DESCRIPTION
When trying to configure `num_proposal_samples_per_ray ` for bakedsdf with `--pipeline.model.num_proposal_samples_per_ray X X`, I encountered issues because the type annotation was set to `Tuple[int]`.
This made it such that the CI would not accept two integers for the two proposal networks, but would rather only expect a single one.

I've made the fix not only for bakedsdf, but also for nerfacto and neus_facto.

Given that other models use 1-2 proposal networks as well, instead of using `Tuple[int, int]`, I've modified the annotation from `Tuple[int]` to `Tuple[int, ...]` to support both singular and multiple proposal network parameters used by a model.