### PR TITLE
added center-method focus to sdfstudio-data

### DIFF
--- a/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/nerfstudio_dataparser.py
@@ -56,8 +56,10 @@ class NerfstudioDataParserConfig(DataParserConfig):
     """How much to scale the region of interest by."""
     orientation_method: Literal["pca", "up", "none"] = "up"
     """The method to use for orientation."""
-    center_poses: bool = True
-    """Whether to center the poses."""
+    # center_poses: bool = True
+    # """Whether to center the poses."""
+    center_method: Literal["poses", "focus", "none"] = "poses"
+    """The method to use to center the poses"""
     auto_scale_poses: bool = True
     """Whether to automatically scale the poses to fit in +/- 1 bounding box."""
     train_split_percentage: float = 0.9
@@ -189,7 +191,7 @@ class Nerfstudio(DataParser):
         poses, transform_matrix = camera_utils.auto_orient_and_center_poses(
             poses,
             method=orientation_method,
-            center_poses=self.config.center_poses,
+            center_method=self.config.center_method,
         )
 
         # Scale poses

--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -157,7 +157,7 @@ class SDFStudioDataParserConfig(DataParserConfig):
     # """How much to downscale images. If not set, images are chosen such that the max dimension is <1600px."""
     orientation_method: Literal["up", "none"] = "up"
     """The method to use for orientation."""
-    center_poses: bool = False
+    center_method: Literal["focus", "none"] = "focus"
     """Whether to center the poses."""
     auto_scale_poses: bool = False
     """Whether to automatically scale the poses to fit in +/- 1 bounding box."""
@@ -310,7 +310,7 @@ class SDFStudio(DataParser):
             camera_to_worlds, transform = camera_utils.auto_orient_and_center_poses(
                 camera_to_worlds,
                 method=orientation_method,
-                center_poses=self.config.center_poses,
+                center_method=self.config.center_method,
             )
 
             # we should also transform normal accordingly

--- a/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
+++ b/nerfstudio/data/dataparsers/sdfstudio_dataparser.py
@@ -15,6 +15,7 @@
 """Data parser for friends dataset"""
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Optional, Type
@@ -34,6 +35,7 @@ from nerfstudio.data.dataparsers.base_dataparser import (
     DataparserOutputs,
 )
 from nerfstudio.data.scene_box import SceneBox
+from nerfstudio.data.utils.data_utils import create_masked_img
 from nerfstudio.utils.images import BasicImages
 from nerfstudio.utils.io import load_from_json
 
@@ -176,6 +178,12 @@ class SDFStudioDataParserConfig(DataParserConfig):
     """automatically orient the scene such that the up direction is the same as the viewer's up direction"""
     load_dtu_highres: bool = False
     """load high resolution images from DTU dataset, should only be used for the preprocessed DTU dataset"""
+    train_with_masked_imgs: bool = False
+    """whether or not to mask out objects using foreground masks and train with masked images"""
+    sample_from_mask: bool = False
+    """if true, pixels are sampled only from masked regions"""
+    masked_img_dir: str = "masked_images"
+    """name of the folder where masked images are stored if train_with_masked_imgs is true"""
 
 
 def filter_list(list_to_filter, indices):
@@ -209,6 +217,7 @@ class SDFStudio(DataParser):
 
         image_filenames = []
         depth_images = []
+        mask_filenames = []
         normal_images = []
         sensor_depth_images = []
         foreground_mask_images = []
@@ -220,6 +229,35 @@ class SDFStudio(DataParser):
         camera_to_worlds = []
         for i, frame in enumerate(meta["frames"]):
             image_filename = self.config.data / frame["rgb_path"]
+
+
+            if (
+                self.config.train_with_masked_imgs
+                or self.config.include_foreground_mask
+                or self.config.sample_from_mask
+            ):
+                assert meta["has_foreground_mask"]
+                mask_filename = self.config.data / frame["foreground_mask"]
+                mask = np.array(Image.open(mask_filename), dtype=np.float32) / 255.0
+                if len(mask.shape) == 3:
+                    mask = mask[..., 0]
+                if self.config.train_with_masked_imgs or self.config.sample_from_mask:
+                    masked_img_dir_path = self.config.data / self.config.masked_img_dir
+                    os.makedirs(str(masked_img_dir_path), exist_ok=True)
+
+            if self.config.train_with_masked_imgs:
+                image_filename = create_masked_img(image_filename, mask_filename, masked_img_dir_path)
+
+            if self.config.include_foreground_mask:
+                foreground_mask = mask[..., None]
+                foreground_mask_images.append(torch.from_numpy(foreground_mask).float())
+
+            if self.config.sample_from_mask:
+                # nerfstudio's pixel sampler requires single channel masks
+                mask_img = Image.fromarray((255.0 * mask).astype(np.uint8))
+                mask_filename = masked_img_dir_path / mask_filename.name
+                mask_img.save(mask_filename)
+                mask_filenames.append(mask_filename)
 
             intrinsics = torch.tensor(frame["intrinsics"])
             camtoworld = torch.tensor(frame["camtoworld"])
@@ -236,6 +274,8 @@ class SDFStudio(DataParser):
                 assert meta["has_mono_prior"]
                 # load mono depth
                 depth = np.load(self.config.data / frame["mono_depth_path"])
+                if self.config.train_with_masked_imgs:
+                    depth = depth * mask
                 depth_images.append(torch.from_numpy(depth).float())
 
                 # load mono normal
@@ -258,6 +298,9 @@ class SDFStudio(DataParser):
                 assert meta["has_sensor_depth"]
                 # load sensor depth
                 sensor_depth = np.load(self.config.data / frame["sensor_depth_path"])
+                if self.config.train_with_masked_imgs:
+                    # TODO: Maybe set background depth to very large value instead of 0?
+                    sensor_depth = sensor_depth * mask
                 sensor_depth_images.append(torch.from_numpy(sensor_depth).float())
 
             if self.config.include_foreground_mask:
@@ -418,6 +461,7 @@ class SDFStudio(DataParser):
         dataparser_outputs = DataparserOutputs(
             image_filenames=filter_list(image_filenames, indices),
             cameras=cameras,
+            mask_filenames=mask_filenames if self.config.sample_from_mask else None,
             scene_box=scene_box,
             additional_inputs=additional_inputs_dict,
             depths=filter_list(depth_images, indices),

--- a/nerfstudio/data/utils/nerfstudio_collate.py
+++ b/nerfstudio/data/utils/nerfstudio_collate.py
@@ -23,7 +23,6 @@ from typing import Callable, Dict, Union
 
 import torch
 import torch.utils.data
-from torch._six import string_classes
 
 from nerfstudio.cameras.cameras import Cameras
 from nerfstudio.utils.images import BasicImages
@@ -120,7 +119,7 @@ def nerfstudio_collate(
         return torch.tensor(batch, dtype=torch.float64)
     elif isinstance(elem, int):
         return torch.tensor(batch)
-    elif isinstance(elem, string_classes):
+    elif isinstance(elem, str):
         return batch
     elif isinstance(elem, collections.abc.Mapping):
         try:

--- a/scripts/datasets/process_nerfstudio_to_sdfstudio.py
+++ b/scripts/datasets/process_nerfstudio_to_sdfstudio.py
@@ -199,6 +199,9 @@ def main(args):
             frame["mono_depth_path"] = rgb_path.replace("_rgb.png", "_depth.npy")
             frame["mono_normal_path"] = rgb_path.replace("_rgb.png", "_normal.npy")
 
+        if args.foreground_mask:
+            frame["foreground_mask"] = rgb_path.replace("_rgb.png", "_mask.png")
+
         frames.append(frame)
         out_index += 1
 
@@ -209,7 +212,7 @@ def main(args):
         "width": tar_w,
         "has_mono_prior": args.mono_prior,
         "has_sensor_depth": args.sensor_depth,
-        "has_foreground_mask": False,
+        "has_foreground_mask": args.foreground_mask,
         "pairs": None,
         "worldtogt": scale_mat.tolist(),
         "scene_box": scene_box,
@@ -261,6 +264,8 @@ if __name__ == "__main__":
     parser.add_argument("--mono-prior", dest="mono_prior", action="store_true",
                         help="Whether to generate mono-prior depths and normals. "
                              "If enabled, the images will be cropped to 384*384")
+    parser.add_argument("--foreground-mask", dest="foreground_mask", action="store_true",
+                        help="Whether to add foreground masks to the json file")
     parser.add_argument("--crop-mult", dest="crop_mult", type=int, default=1,
                         help="image size will be resized to crop_mult*384, only take effect when enabling mono-prior")
     parser.add_argument("--omnidata-path", dest="omnidata_path",


### PR DESCRIPTION
A quick update do sdfstudio dataparser allowing users to choose "focus" to center poses.
An example: `ns-train neus sdfstudio-data ./mydata --center-method focus`
Tested with neus and neus-facto with my own datasets after running `process_nerfstudio_to_sdfstudio.py`

I've used the code from the updated version of nerfstudio repo.

Note: the change I did in nerfstudio_collate.py to remove torch._six.string_classes was to make it compatible with new versions of pytorch. I've been using pytorch 2.0.1 by the way. 