### PR TITLE
add support for s3im loss in sdfstudio

### DIFF
--- a/nerfstudio/model_components/losses.py
+++ b/nerfstudio/model_components/losses.py
@@ -20,6 +20,9 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 from torchtyping import TensorType
+from torch.autograd import Variable
+import numpy as np
+from math import exp
 
 from nerfstudio.cameras.rays import RaySamples
 from nerfstudio.field_components.field_heads import FieldHeadNames
@@ -671,3 +674,98 @@ class SensorDepthLoss(nn.Module):
         sdf_loss = torch.mean(((z_vals + pred_sdf) - depth_gt) ** 2 * sdf_mask) * sdf_weight
 
         return l1_loss, free_space_loss, sdf_loss
+
+r"""Implements Stochastic Structural SIMilarity(S3IM) algorithm.
+It is proposed in the ICCV2023 paper  
+`S3IM: Stochastic Structural SIMilarity and Its Unreasonable Effectiveness for Neural Fields`.
+
+Arguments:
+    s3im_kernel_size (int): kernel size in ssim's convolution(default: 4)
+    s3im_stride (int): stride in ssim's convolution(default: 4)
+    s3im_repeat_time (int): repeat time in re-shuffle virtual patch(default: 10)
+    s3im_patch_height (height): height of virtual patch(default: 64)
+"""
+
+class S3IM(torch.nn.Module):
+    def __init__(self, s3im_kernel_size = 4, s3im_stride=4, s3im_repeat_time=10, s3im_patch_height=64, size_average = True):
+        super(S3IM, self).__init__()
+        self.s3im_kernel_size = s3im_kernel_size
+        self.s3im_stride = s3im_stride
+        self.s3im_repeat_time = s3im_repeat_time
+        self.s3im_patch_height = s3im_patch_height
+        self.size_average = size_average
+        self.channel = 1
+        self.s3im_kernel = self.create_kernel(s3im_kernel_size, self.channel)
+
+    
+    def gaussian(self, s3im_kernel_size, sigma):
+        gauss = torch.Tensor([exp(-(x - s3im_kernel_size//2)**2/float(2*sigma**2)) for x in range(s3im_kernel_size)])
+        return gauss/gauss.sum()
+
+    def create_kernel(self, s3im_kernel_size, channel):
+        _1D_window = self.gaussian(s3im_kernel_size, 1.5).unsqueeze(1)
+        _2D_window = _1D_window.mm(_1D_window.t()).float().unsqueeze(0).unsqueeze(0)
+        s3im_kernel = Variable(_2D_window.expand(channel, 1, s3im_kernel_size, s3im_kernel_size).contiguous())
+        return s3im_kernel
+
+    def _ssim(self, img1, img2, s3im_kernel, s3im_kernel_size, channel, size_average = True, s3im_stride=None):
+        mu1 = F.conv2d(img1, s3im_kernel, padding = (s3im_kernel_size-1)//2, groups = channel, stride=s3im_stride)
+        mu2 = F.conv2d(img2, s3im_kernel, padding = (s3im_kernel_size-1)//2, groups = channel, stride=s3im_stride)
+
+        mu1_sq = mu1.pow(2)
+        mu2_sq = mu2.pow(2)
+        mu1_mu2 = mu1*mu2
+
+        sigma1_sq = F.conv2d(img1*img1, s3im_kernel, padding = (s3im_kernel_size-1)//2, groups = channel, stride=s3im_stride) - mu1_sq
+        sigma2_sq = F.conv2d(img2*img2, s3im_kernel, padding = (s3im_kernel_size-1)//2, groups = channel, stride=s3im_stride) - mu2_sq
+        sigma12 = F.conv2d(img1*img2, s3im_kernel, padding = (s3im_kernel_size-1)//2, groups = channel, stride=s3im_stride) - mu1_mu2
+
+        C1 = 0.01**2
+        C2 = 0.03**2
+
+        ssim_map = ((2*mu1_mu2 + C1)*(2*sigma12 + C2))/((mu1_sq + mu2_sq + C1)*(sigma1_sq + sigma2_sq + C2))
+
+        if size_average:
+            return ssim_map.mean()
+        else:
+            return ssim_map.mean(1).mean(1).mean(1)
+    
+    def ssim_loss(self, img1, img2):
+        """
+        img1, img2: torch.Tensor([b,c,h,w])
+        """
+        (_, channel, _, _) = img1.size()
+
+        if channel == self.channel and self.s3im_kernel.data.type() == img1.data.type():
+            s3im_kernel = self.s3im_kernel
+        else:
+            s3im_kernel = self.create_kernel(self.s3im_kernel_size, channel)
+
+            if img1.is_cuda:
+                s3im_kernel = s3im_kernel.cuda(img1.get_device())
+            s3im_kernel = s3im_kernel.type_as(img1)
+
+            self.s3im_kernel = s3im_kernel
+            self.channel = channel
+
+
+        return self._ssim(img1, img2, s3im_kernel, self.s3im_kernel_size, channel, self.size_average, s3im_stride=self.s3im_stride)
+
+    def forward(self, src_vec, tar_vec):
+        loss = 0.0
+        index_list = []
+        for i in range(self.s3im_repeat_time):
+            if i == 0:
+                tmp_index = torch.arange(len(tar_vec))
+                index_list.append(tmp_index)
+            else:
+                ran_idx = torch.randperm(len(tar_vec))
+                index_list.append(ran_idx)
+        res_index = torch.cat(index_list)
+        tar_all = tar_vec[res_index]
+        src_all = src_vec[res_index]
+        tar_patch = tar_all.permute(1, 0).reshape(1, 3, self.s3im_patch_height, -1)
+        src_patch = src_all.permute(1, 0).reshape(1, 3, self.s3im_patch_height, -1)
+        loss = (1 - self.ssim_loss(src_patch, tar_patch))
+        return loss
+

--- a/nerfstudio/models/bakedsdf.py
+++ b/nerfstudio/models/bakedsdf.py
@@ -90,17 +90,6 @@ class BakedSDFModelConfig(VolSDFModelConfig):
     eikonal_loss_mult_start: float = 0.01
     eikonal_loss_mult_end: float = 0.1
     eikonal_loss_mult_slop: float = 2.0
-    s3im_loss_mult: float = 0.0
-    """S3IM loss multiplier."""
-    s3im_kernel_size: int = 4
-    """S3IM kernel size."""
-    s3im_stride: int = 4
-    """S3IM stride."""
-    s3im_repeat_time: int = 10
-    """S3IM repeat time."""
-    s3im_patch_height: int = 32
-    """S3IM virtual patch height."""
-
 
 class BakedSDFFactoModel(VolSDFModel):
     """BakedSDF model

--- a/nerfstudio/models/bakedsdf.py
+++ b/nerfstudio/models/bakedsdf.py
@@ -90,6 +90,16 @@ class BakedSDFModelConfig(VolSDFModelConfig):
     eikonal_loss_mult_start: float = 0.01
     eikonal_loss_mult_end: float = 0.1
     eikonal_loss_mult_slop: float = 2.0
+    s3im_loss_mult: float = 0.0
+    """S3IM loss multiplier."""
+    s3im_kernel_size: int = 4
+    """S3IM kernel size."""
+    s3im_stride: int = 4
+    """S3IM stride."""
+    s3im_repeat_time: int = 10
+    """S3IM repeat time."""
+    s3im_patch_height: int = 32
+    """S3IM virtual patch height."""
 
 
 class BakedSDFFactoModel(VolSDFModel):
@@ -264,6 +274,9 @@ class BakedSDFFactoModel(VolSDFModel):
         if self.training:
             # eikonal loss
             grad_theta = outputs["eik_grad"]
+            # s3im loss
+            if self.config.s3im_loss_mult > 0:
+                loss_dict["s3im_loss"] = self.s3im_loss(image, outputs["rgb"]) * self.config.s3im_loss_mult
             if self.config.use_spatial_varying_eikonal_loss:
 
                 points_norm = outputs["points_norm"][..., 0]

--- a/nerfstudio/models/base_surface_model.py
+++ b/nerfstudio/models/base_surface_model.py
@@ -221,7 +221,7 @@ class SurfaceModel(Model):
 
         # losses
         self.rgb_loss = L1Loss()
-        self.s3im_loss = S3IM(kernel_size=self.config.s3im_kernel_size, stride=self.config.s3im_stride, repeat_time=self.config.s3im_repeat_time, patch_height=self.config.s3im_patch_height, patch_width=self.config.s3im_patch_width)
+        self.s3im_loss = S3IM(s3im_kernel_size=self.config.s3im_kernel_size, s3im_stride=self.config.s3im_stride, s3im_repeat_time=self.config.s3im_repeat_time, s3im_patch_height=self.config.s3im_patch_height)
 
         self.eikonal_loss = MSELoss()
         self.depth_loss = ScaleAndShiftInvariantLoss(alpha=0.5, scales=1)

--- a/nerfstudio/models/dto.py
+++ b/nerfstudio/models/dto.py
@@ -147,7 +147,7 @@ class DtoOModel(NerfactoModel):
         self.method = "neus"
 
         self.rgb_loss = L1Loss()
-        self.s3im_loss = S3IM(kernel_size=self.config.s3im_kernel_size, stride=self.config.s3im_stride, repeat_time=self.config.s3im_repeat_time, patch_height=self.config.s3im_patch_height, patch_width=self.config.s3im_patch_width)
+        self.s3im_loss = S3IM(s3im_kernel_size=self.config.s3im_kernel_size, s3im_stride=self.config.s3im_stride, s3im_repeat_time=self.config.s3im_repeat_time, s3im_patch_height=self.config.s3im_patch_height)
 
 
     def get_training_callbacks(

--- a/nerfstudio/models/tensorf.py
+++ b/nerfstudio/models/tensorf.py
@@ -72,6 +72,16 @@ class TensoRFModelConfig(ModelConfig):
     """Number of components in color encoding"""
     appearance_dim: int = 27
     """Number of channels for color encoding"""
+    s3im_loss_mult: float = 0.0
+    """S3IM loss multiplier."""
+    s3im_kernel_size: int = 4
+    """S3IM kernel size."""
+    s3im_stride: int = 4
+    """S3IM stride."""
+    s3im_repeat_time: int = 10
+    """S3IM repeat time."""
+    s3im_patch_height: int = 32
+    """S3IM virtual patch height."""
 
 
 class TensoRFModel(Model):
@@ -183,6 +193,8 @@ class TensoRFModel(Model):
 
         # losses
         self.rgb_loss = MSELoss()
+        self.s3im_loss = S3IM(kernel_size=self.config.s3im_kernel_size, stride=self.config.s3im_stride, repeat_time=self.config.s3im_repeat_time, patch_height=self.config.s3im_patch_height, patch_width=self.config.s3im_patch_width)
+
 
         # metrics
         self.psnr = PeakSignalNoiseRatio(data_range=1.0)
@@ -245,8 +257,10 @@ class TensoRFModel(Model):
         image = batch["image"].to(device)
 
         rgb_loss = self.rgb_loss(image, outputs["rgb"])
-
         loss_dict = {"rgb_loss": rgb_loss}
+        # s3im loss
+        if self.config.s3im_loss_mult > 0:
+            loss_dict["s3im_loss"] = self.s3im_loss(image, outputs["rgb"]) * self.config.s3im_loss_mult
         loss_dict = misc.scale_dict(loss_dict, self.config.loss_coefficients)
         return loss_dict
 

--- a/nerfstudio/models/tensorf.py
+++ b/nerfstudio/models/tensorf.py
@@ -193,7 +193,7 @@ class TensoRFModel(Model):
 
         # losses
         self.rgb_loss = MSELoss()
-        self.s3im_loss = S3IM(kernel_size=self.config.s3im_kernel_size, stride=self.config.s3im_stride, repeat_time=self.config.s3im_repeat_time, patch_height=self.config.s3im_patch_height, patch_width=self.config.s3im_patch_width)
+        self.s3im_loss = S3IM(s3im_kernel_size=self.config.s3im_kernel_size, s3im_stride=self.config.s3im_stride, s3im_repeat_time=self.config.s3im_repeat_time, s3im_patch_height=self.config.s3im_patch_height)
 
 
         # metrics

--- a/nerfstudio/models/vanilla_nerf.py
+++ b/nerfstudio/models/vanilla_nerf.py
@@ -33,7 +33,7 @@ from nerfstudio.field_components.encodings import NeRFEncoding
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.field_components.temporal_distortions import TemporalDistortionKind
 from nerfstudio.fields.vanilla_nerf_field import NeRFField
-from nerfstudio.model_components.losses import MSELoss
+from nerfstudio.model_components.losses import MSELoss, S3IM
 from nerfstudio.model_components.ray_samplers import PDFSampler, UniformSampler
 from nerfstudio.model_components.renderers import (
     AccumulationRenderer,
@@ -58,6 +58,16 @@ class VanillaModelConfig(ModelConfig):
     """Specifies whether or not to include ray warping based on time."""
     temporal_distortion_params: Dict[str, Any] = to_immutable_dict({"kind": TemporalDistortionKind.DNERF})
     """Parameters to instantiate temporal distortion with"""
+    s3im_loss_mult: float = 0.0
+    """S3IM loss multiplier."""
+    s3im_kernel_size: int = 4
+    """S3IM kernel size."""
+    s3im_stride: int = 4
+    """S3IM stride."""
+    s3im_repeat_time: int = 10
+    """S3IM repeat time."""
+    s3im_patch_height: int = 32
+    """S3IM virtual patch height."""
 
 
 class NeRFModel(Model):
@@ -75,6 +85,8 @@ class NeRFModel(Model):
         self.field_coarse = None
         self.field_fine = None
         self.temporal_distortion = None
+        self.s3im_func = S3IM(kernel_size=self.config.s3im_kernel_size, stride=self.config.s3im_stride, repeat_time=self.config.s3im_repeat_time, patch_height=self.config.s3im_patch_height, patch_width=self.config.s3im_patch_width)
+
 
         super().__init__(
             config=config,

--- a/nerfstudio/models/vanilla_nerf.py
+++ b/nerfstudio/models/vanilla_nerf.py
@@ -33,7 +33,7 @@ from nerfstudio.field_components.encodings import NeRFEncoding
 from nerfstudio.field_components.field_heads import FieldHeadNames
 from nerfstudio.field_components.temporal_distortions import TemporalDistortionKind
 from nerfstudio.fields.vanilla_nerf_field import NeRFField
-from nerfstudio.model_components.losses import MSELoss, S3IM
+from nerfstudio.model_components.losses import MSELoss
 from nerfstudio.model_components.ray_samplers import PDFSampler, UniformSampler
 from nerfstudio.model_components.renderers import (
     AccumulationRenderer,
@@ -58,16 +58,6 @@ class VanillaModelConfig(ModelConfig):
     """Specifies whether or not to include ray warping based on time."""
     temporal_distortion_params: Dict[str, Any] = to_immutable_dict({"kind": TemporalDistortionKind.DNERF})
     """Parameters to instantiate temporal distortion with"""
-    s3im_loss_mult: float = 0.0
-    """S3IM loss multiplier."""
-    s3im_kernel_size: int = 4
-    """S3IM kernel size."""
-    s3im_stride: int = 4
-    """S3IM stride."""
-    s3im_repeat_time: int = 10
-    """S3IM repeat time."""
-    s3im_patch_height: int = 32
-    """S3IM virtual patch height."""
 
 
 class NeRFModel(Model):
@@ -85,7 +75,6 @@ class NeRFModel(Model):
         self.field_coarse = None
         self.field_fine = None
         self.temporal_distortion = None
-        self.s3im_func = S3IM(kernel_size=self.config.s3im_kernel_size, stride=self.config.s3im_stride, repeat_time=self.config.s3im_repeat_time, patch_height=self.config.s3im_patch_height, patch_width=self.config.s3im_patch_width)
 
 
         super().__init__(


### PR DESCRIPTION
I added S3IM loss in sdf related function, which is simple and effective. Our paper [S3IM](https://arxiv.org/abs/2308.07032) achieved very impressive results in surface reconstruction.
[S3IM: Stochastic Structural SIMilarity and Its Unreasonable Effectiveness for Neural Fields](https://arxiv.org/abs/2308.07032)
<img width="669" alt="neus compare" src="https://github.com/autonomousvision/sdfstudio/assets/111342277/59e58f68-a79e-4076-9e1a-58e7148b7078">

<img width="1138" alt="neus + s3im in replica" src="https://github.com/autonomousvision/sdfstudio/assets/111342277/f2d93175-7365-4edb-acfc-5d008932aaa9">

Simply add --pipeline.model.s3im_loss_mult, then SDF + S3IM will start to train.

`ns-train neus --pipeline.model.s3im_loss_mult ${weight of s3im loss} sdfstudio-data`
