### PR TITLE
fix 'typing' to 'typing_extensions' for python3.7

### DIFF
--- a/nerfstudio/data/dataparsers/monosdf_dataparser.py
+++ b/nerfstudio/data/dataparsers/monosdf_dataparser.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from glob import glob
 from pathlib import Path
-from typing import Dict, Literal, Optional, Type
+from typing_extensions import Dict, Literal, Optional, Type
 
 import cv2
 import numpy as np

--- a/scripts/extract_mesh.py
+++ b/scripts/extract_mesh.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Tuple
+from typing_extensions import Literal, Tuple
 
 import torch
 import tyro


### PR DESCRIPTION
ImportError: cannot import name 'Literal' from 'typing' occurs when installing SDFstudio in Python3.7.

The error occurs because tying.Literal is only available from Python3.8 and up.

It is stated that SDFstudio requires python >= 3.7 in README.md, so I fixed some codes to use Literal in older Python versions.