### PR TITLE
Update nerfstudio_collate.py

### DIFF
--- a/nerfstudio/data/utils/nerfstudio_collate.py
+++ b/nerfstudio/data/utils/nerfstudio_collate.py
@@ -23,7 +23,12 @@ from typing import Callable, Dict, Union
 
 import torch
 import torch.utils.data
-from torch._six import string_classes
+try:
+    # old PyTorch compatibility
+    from torch._six import string_classes
+except ImportError:
+    # fallback for torch versions that dropped _six
+    string_classes = (str,)
 
 from nerfstudio.cameras.cameras import Cameras
 from nerfstudio.utils.images import BasicImages


### PR DESCRIPTION
Fix removed class usage "torch._six" which is dropped in later Pytorch 2.x releases.